### PR TITLE
Cleanup on player quit

### DIFF
--- a/src/main/java/me/bristermitten/packetlimiter/PacketLimiter.java
+++ b/src/main/java/me/bristermitten/packetlimiter/PacketLimiter.java
@@ -10,6 +10,9 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.lang.reflect.InvocationTargetException;
@@ -17,7 +20,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class PacketLimiter extends JavaPlugin {
+public final class PacketLimiter extends JavaPlugin implements Listener {
     private static final int DEFAULT_MAX_PACKETS = 15;
     private static final String DEBUG_PREFIX = "[Debug] ";
     private final ConcurrentPlayerMap<Queue<PacketContainer>> packetQueue =
@@ -70,6 +73,8 @@ public final class PacketLimiter extends JavaPlugin {
                         debugLog("Resent {} packets to {}", i, player.getName());
                     }
                 }), 0L, 1L);
+
+        Bukkit.getPluginManager().registerEvents(this, this);
     }
 
     private void registerPacketListener(ProtocolManager protocolManager) {
@@ -92,5 +97,12 @@ public final class PacketLimiter extends JavaPlugin {
 
     private int getMaxPackets() {
         return getConfig().getInt("max-packets-per-tick", DEFAULT_MAX_PACKETS);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        var player = e.getPlayer();
+        packetQueue.remove(player);
+        packetsSentInTick.remove(player);
     }
 }


### PR DESCRIPTION
Since Player class is bound to individual player connection, if player leaves the server and joins back again, packages will still be sent to their previous connection that no longer exists, which means they will not be delivered delayed packages until the server restart / plugin reload.

This PR adds a listener for player quit event and performs a cleanup, disposing queue and counter reference. They will be re-created once player joins back again.