### PR TITLE
Config pre-loading and value guard

### DIFF
--- a/src/main/java/me/bristermitten/packetlimiter/PacketLimiter.java
+++ b/src/main/java/me/bristermitten/packetlimiter/PacketLimiter.java
@@ -25,8 +25,11 @@ public final class PacketLimiter extends JavaPlugin {
     private final ConcurrentPlayerMap<AtomicInteger> packetsSentInTick =
             new ConcurrentPlayerMap<>(ConcurrentPlayerMap.PlayerKey.NAME);
 
+    private boolean debugEnabled = false;
+    private int maxPackets = DEFAULT_MAX_PACKETS;
+
     private void debugLog(String format, Object arg1, Object arg2) {
-        if (getConfig().getBoolean("debug")) {
+        if (debugEnabled) {
             var message = DEBUG_PREFIX + format;
             getSLF4JLogger().info(message, arg1, arg2);
         }
@@ -43,6 +46,9 @@ public final class PacketLimiter extends JavaPlugin {
     @Override
     public void onEnable() {
         saveDefaultConfig();
+
+        reloadConfig();
+
         //noinspection ConstantConditions
         getCommand("paperlagreload").setExecutor(new ReloadCommand(this));
 
@@ -54,7 +60,7 @@ public final class PacketLimiter extends JavaPlugin {
                     getPacketsSentInTick(player).set(0); // Reset packet counter for this tick
                     int i;
                     // re-send no more than the maximum packets
-                    for (i = 0; i < getMaxPackets(); i++) {
+                    for (i = 0; i < maxPackets; i++) {
                         final var packet = queue.poll();
                         if (packet == null) {
                             break;
@@ -72,6 +78,24 @@ public final class PacketLimiter extends JavaPlugin {
                 }), 0L, 1L);
     }
 
+    @Override
+    public void reloadConfig() {
+        super.reloadConfig();
+
+        var config = getConfig();
+
+        debugEnabled = config.getBoolean("debug");
+
+        var $maxPackets = config.getInt("max-packets-per-tick", DEFAULT_MAX_PACKETS);
+
+        if ($maxPackets < 1) {
+            maxPackets = DEFAULT_MAX_PACKETS;
+            getSLF4JLogger().warn("Illegal value for option `max-packets-per-tick`: {}. Using default value of {}", $maxPackets, DEFAULT_MAX_PACKETS);
+        } else {
+            maxPackets = $maxPackets;
+        }
+    }
+
     private void registerPacketListener(ProtocolManager protocolManager) {
         protocolManager.addPacketListener(new PacketAdapter(this, ListenerPriority.HIGHEST, PacketType.Play.Server.MAP_CHUNK) {
             @Override
@@ -80,7 +104,6 @@ public final class PacketLimiter extends JavaPlugin {
                 debugLog("Intercepting packet send {} to player {}", packet, event.getPlayer());
 
                 final int sentInTick = getPacketsSentInTick(event.getPlayer()).incrementAndGet();
-                final int maxPackets = getMaxPackets();
                 if (sentInTick > maxPackets) {
                     event.setCancelled(true);
                     debugLog("Cancelling chunk packet to player {} {}", event.getPlayer(), packet);
@@ -88,9 +111,5 @@ public final class PacketLimiter extends JavaPlugin {
                 }
             }
         });
-    }
-
-    private int getMaxPackets() {
-        return getConfig().getInt("max-packets-per-tick", DEFAULT_MAX_PACKETS);
     }
 }


### PR DESCRIPTION
Instead of querying values every time, store them in class fields and refresh with config reload. Add a guard as well to max-packets-per-tick option preventing values that could cause infinite queues (all values below 1).